### PR TITLE
Fix release and clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<CONFIG:Debug>:>
 
     $<$<CONFIG:Release>:
-        -flto=auto
+    #    -flto=auto
     >
 
     $<$<COMPILE_LANG_AND_ID:C,GNU>:

--- a/include/hlib/buffer.hpp
+++ b/include/hlib/buffer.hpp
@@ -118,7 +118,7 @@ public:
         return reinterpret_cast<T*>(ptr + m_size);
     }
 
-    void deallocate(T* ptr, std::size_t size) noexcept
+    void deallocate(__attribute__((unused)) T* ptr, __attribute__((unused)) std::size_t size) noexcept
     {
         assert(static_cast<std::uint8_t const*>(m_buffer.data()) + m_size == reinterpret_cast<std::uint8_t*>(ptr));
         assert(m_buffer.size() == m_size + size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<CONFIG:Debug>:>
 
     $<$<CONFIG:Release>:
-        -flto=auto
+    #    -flto=auto
     >
 
     $<$<COMPILE_LANG_AND_ID:C,GNU>:


### PR DESCRIPTION
Disabled LTO because it gives issues with clang.
Fixed an unused parameter error in release builds.